### PR TITLE
FIX: Lotus::Assets::Precompiler#basename cut all after first dot in f…

### DIFF
--- a/lib/lotus/assets/config/sources.rb
+++ b/lib/lotus/assets/config/sources.rb
@@ -34,7 +34,7 @@ module Lotus
 
           Dir.glob(map {|source| "#{ source }/**/#{ name }*"}).each do |file|
             next if ::File.directory?(file) || ::File.basename(file).match(/\A\_/)
-            result << file
+            result << file.to_s
           end
 
           result

--- a/lib/lotus/assets/precompiler.rb
+++ b/lib/lotus/assets/precompiler.rb
@@ -12,7 +12,7 @@ module Lotus
           config.compile true
 
           config.files.each do |file|
-            Compiler.compile(config, file.to_s, basename(file))
+            Compiler.compile(config, file, basename(file))
           end
         end
       end
@@ -25,9 +25,7 @@ module Lotus
       end
 
       def basename(file)
-        File.basename(
-          file.to_s.sub(/\.(.*)\z/, '')
-        )
+        File.basename(file, File.extname(file))
       end
     end
   end


### PR DESCRIPTION
…ilename
